### PR TITLE
Fix for Issue #1: QModel encounters 'charmap' error using PYTHONW.exe

### DIFF
--- a/QATCH/__main__.py
+++ b/QATCH/__main__.py
@@ -1,5 +1,16 @@
-from QATCH.app import QATCH
-
+from QATCH.core.constants import MinimalPython
+import os
 
 if __name__ == '__main__':
-    QATCH().run()
+    with open("QATCH\__pythonw__.vbs", "w") as f:
+        f.writelines([
+            'Set WshShell = CreateObject("WScript.Shell")\n',
+            'WshShell.Run "py -{}.{} app.py", 0, True\n'.format(
+                MinimalPython.major, 
+                MinimalPython.minor
+            ),
+            'Set WshShell = Nothing\n'
+        ])
+    os.startfile("QATCH\__pythonw__.vbs")
+    #freeze_support()
+    #QATCH().run()

--- a/QATCH/app.py
+++ b/QATCH/app.py
@@ -42,6 +42,13 @@ class QATCH:
             self.flashSplashShow()
         print("Launching application...")
         if Architecture.get_os() is OSType.windows:
+            myappid = "{} {} {} ({})".format(
+                Constants.app_publisher,
+                Constants.app_name,
+                Constants.app_version,
+                Constants.app_date
+            ) # arbitrary string, required for Windows Toolbar to display QATCH iocn
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
             ctypes.windll.kernel32.SetConsoleTitleW("QATCH Q-1 Real-Time GUI - command line")
         self._args = self._init_logger()
         self._app = QApplication(argv)

--- a/QATCH/core/constants.py
+++ b/QATCH/core/constants.py
@@ -17,7 +17,7 @@ class OperationType(Enum):
 ###############################################################################
 class MinimalPython:
     major = 3
-    minor = 10
+    minor = 11
     release = 0
 
 

--- a/app.py
+++ b/app.py
@@ -42,6 +42,13 @@ class QATCH:
             self.flashSplashShow()
         print("Launching application...")
         if Architecture.get_os() is OSType.windows:
+            myappid = "{} {} {} ({})".format(
+                Constants.app_publisher,
+                Constants.app_name,
+                Constants.app_version,
+                Constants.app_date
+            ) # arbitrary string, required for Windows Toolbar to display QATCH iocn
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
             ctypes.windll.kernel32.SetConsoleTitleW("QATCH Q-1 Real-Time GUI - command line")
         self._args = self._init_logger()
         self._app = QApplication(argv)


### PR DESCRIPTION
Hacky fix to use the regular PYTHON.exe instead of PYTHONW.exe, using a helper VBS file to launch the application while hiding the console window from the user. A helpful code snippet was found by Paul to allow the toolbar icon to still show correctly.

The underlying issue was that QModel would not run, reporting some kind of Unicode encoding error (exact source undetermined) when trying to read from the capture.zip file. The issue goes away when using the regular PYTHON.exe interpreter.