### PR TITLE
Fix #5

### DIFF
--- a/QATCH/processors/Elaborate.py
+++ b/QATCH/processors/Elaborate.py
@@ -211,7 +211,7 @@ class ElaborateProcess(multiprocessing.Process):
         order_range = range(order+1)
         half_window = (window_size -1) // 2
         # precompute coefficients
-        b = np.mat([[k**i for i in order_range] for k in range(-half_window, half_window+1)])
+        b = np.asmatrix([[k**i for i in order_range] for k in range(-half_window, half_window+1)])
         m = np.linalg.pinv(b).A[deriv] * rate**deriv * factorial(deriv)
         # pad the signal at the extremes with values taken from the signal itself
         firstvals = y[0] - np.abs( y[1:half_window+1][::-1] - y[0] )

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,7 +171,7 @@ requests==2.32.3
     #   -r requirements.in
     #   dropbox
     #   tensorflow-intel
-rich==13.9.3
+rich==13.9.4
     # via keras
 scikit-learn==1.5.1
     # via
@@ -222,7 +222,7 @@ threadpoolctl==3.5.0
     # via
     #   imbalanced-learn
     #   scikit-learn
-tqdm==4.66.6
+tqdm==4.67.0
     # via
     #   -r requirements.in
     #   hyperopt
@@ -236,7 +236,7 @@ tzdata==2024.2
     # via pandas
 urllib3==2.2.3
     # via requests
-werkzeug==3.1.0
+werkzeug==3.1.2
     # via tensorboard
 wheel==0.44.0
     # via astunparse


### PR DESCRIPTION
1 reference to `np.mat` changed to `np.asmatrix` instead, per deprecation in Numpy module. Updated requirements as well.