### PR TITLE
Fixes #23

### DIFF
--- a/QATCH/common/userProfiles.py
+++ b/QATCH/common/userProfiles.py
@@ -434,7 +434,21 @@ class UserProfilesManager(QtWidgets.QWidget):
 
         self.update_table_data()
 
-    def remove_user(self, filename=None):
+    def remove_user(self, filename: str = None):
+        """ Deletes a user given a path to the user profiles file.
+
+        If the filename is not None, administrator authentication is requested.  If an
+        administrator is currently logged in, the delete action is allowed to proceed, otherwise,
+        only non-administrator accounts are allowed to be deleted.  Deleting the last user account
+        triggers additional warning dialogue and resets user fields to default. On delete,
+        the user in the userProfiles file is marked as deleted and the cached user table is updated.
+
+        Parameters:
+            filename (str): the path to the userProfiles file to delete a user from (Optional).
+
+        Returns
+            None
+        """
         action = "Delete User"
 
         if filename == None:
@@ -475,8 +489,11 @@ class UserProfilesManager(QtWidgets.QWidget):
                         self.parent.userrole = UserRoles.NONE
                         self.parent.signinout.setText("&Sign In")
                         self.parent.manage.setText("&Manage Users...")
-                        self.parent.ui1.tool_User.setText(name)
-                        self.parent.parent.AnalyzeProc.tool_User.setText(name)
+
+                        # Set user names to "Anonymous" if there are no users left.
+                        self.parent.ui1.tool_User.setText("Anonymous")
+                        self.parent.parent.AnalyzeProc.tool_User.setText(
+                            "Anonymous")
                         self.close()
                     else:
                         return
@@ -486,7 +503,7 @@ class UserProfilesManager(QtWidgets.QWidget):
 
         file = os.path.join(UserProfiles.PATH, filename)
 
-        # mark user profile as deleted
+        # Mark user profile as deleted
         ts_type = "deleted"
         ts_val = dt.datetime.now().isoformat()
         salt = filename[:-4]
@@ -500,7 +517,7 @@ class UserProfilesManager(QtWidgets.QWidget):
             f.write(
                 f'<timestamp type="{ts_type}" value="{ts_val}" signature="{signature}"/></user_profile>'.encode())
 
-        # delete user
+        # Delete the user.
         folder_name, file_name = os.path.split(file)
         archive_to = os.path.join(folder_name, "archived")
         FileManager.create_dir(archive_to)

--- a/QATCH/ui/mainWindow.py
+++ b/QATCH/ui/mainWindow.py
@@ -5428,7 +5428,7 @@ class TECTask(QtCore.QThread):
     ###########################################################################
     # Automatically selects the serial ports for Teensy (macox/windows)
     ###########################################################################
-    @ staticmethod
+    @staticmethod
     def get_ports():
         return serial.enumerate()
         from QATCH.common.architecture import Architecture, OSType


### PR DESCRIPTION
Simple fix here, simply changed the tool bar text from the name of the last user account signed out to "Anonymous" if there are no more users (lines 480-481) of userProfiles.py:
```
name = self.parent.username.text()[6:]
Log.i(f"Goodbye, {name}! You have been signed out.")
self.parent.username.setText("User: [NONE]")
self.parent.userrole = UserRoles.NONE
self.parent.signinout.setText("&Sign In")
self.parent.manage.setText("&Manage Users...")

# Set user names to "Anonymous" if there are no users left.
self.parent.ui1.tool_User.setText("Anonymous")
self.parent.parent.AnalyzeProc.tool_User.setText("Anonymous")
self.close()
```

Additionally, I added documentation for `userProfiles.remove_user()`.