### PR TITLE
Disabling Live Fill Forecasting

### DIFF
--- a/QATCH/core/constants.py
+++ b/QATCH/core/constants.py
@@ -325,7 +325,7 @@ class Constants:
     # In general, the first model to return a valid result will
     # prevent the execution of lower priority order model(s).
     preload_tensorflow = False  # otherwise, it will be loaded if/when needed
-    USE_MULTIPROCESS_FILL_FORECASTER = True
+    USE_MULTIPROCESS_FILL_FORECASTER = False
     FILL_TYPE_LABEL_MAP = {
         0: "Run: %v/%m (No Fill)",
         1: "Run: %v/%m (Filling)",

--- a/QATCH/ui/mainWindow.py
+++ b/QATCH/ui/mainWindow.py
@@ -3080,10 +3080,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.forecast_status = self._forecaster.update_predictions(
                     new_data=new_data)
 
-            self.ControlsWin.ui1.fill_prediction_progress_bar.setValue(
-                self.forecast_status.value)
-            self.ControlsWin.ui1.fill_prediction_progress_bar.setFormat(
-                Constants.FILL_TYPE_LABEL_MAP.get(self.forecast_status.value, ""))
+            # self.ControlsWin.ui1.fill_prediction_progress_bar.setValue(
+            #     self.forecast_status.value)
+            # self.ControlsWin.ui1.fill_prediction_progress_bar.setFormat(
+            #     Constants.FILL_TYPE_LABEL_MAP.get(self.forecast_status.value, ""))
 
             self._ser_error1, self._ser_error2, self._ser_error3, self._ser_error4, self._ser_control, self._ser_err_usb = self.worker.get_ser_error()
 

--- a/QATCH/ui/mainWindow_ui.py
+++ b/QATCH/ui/mainWindow_ui.py
@@ -1256,25 +1256,25 @@ class Ui_Controls(object):  # QtWidgets.QMainWindow
         self.run_progress_bar.setObjectName("progressBar")
         self.run_progress_bar.setStyleSheet(styleBar)
 
-        self.fill_prediction_progress_bar = QtWidgets.QProgressBar()
-        self.fill_prediction_progress_bar.setMinimum(0)
-        self.fill_prediction_progress_bar.setMaximum(2)
-        self.fill_prediction_progress_bar.setGeometry(
-            QtCore.QRect(0, 0, 50, 10))
-        self.fill_prediction_progress_bar.setObjectName("fillProgressBar")
-        self.fill_prediction_progress_bar.setStyleSheet(styleBar)
+        # self.fill_prediction_progress_bar = QtWidgets.QProgressBar()
+        # self.fill_prediction_progress_bar.setMinimum(0)
+        # self.fill_prediction_progress_bar.setMaximum(2)
+        # self.fill_prediction_progress_bar.setGeometry(
+        #     QtCore.QRect(0, 0, 50, 10))
+        # self.fill_prediction_progress_bar.setObjectName("fillProgressBar")
+        # self.fill_prediction_progress_bar.setStyleSheet(styleBar)
 
         if USE_FULLSCREEN:
             self.run_progress_bar.setFixedHeight(50)
-            self.fill_prediction_progress_bar.setFixedHeight(50)
+            # self.fill_prediction_progress_bar.setFixedHeight(50)
         if SHOW_SIMPLE_CONTROLS:
             self.run_progress_bar.valueChanged.connect(
                 self._update_progress_value)
 
         self.run_progress_bar.setValue(0)
-        self.fill_prediction_progress_bar.setValue(0)
+        # self.fill_prediction_progress_bar.setValue(0)
 
-        self.fill_prediction_progress_bar.setFormat("Run: %v/%m (No Fill)")
+        # self.fill_prediction_progress_bar.setFormat("Run: %v/%m (No Fill)")
 
         self.Layout_controls.setColumnStretch(0, 0)
         self.Layout_controls.setColumnStretch(1, 1)
@@ -1438,7 +1438,7 @@ class Ui_Controls(object):  # QtWidgets.QMainWindow
 
         self.toolLayout.addWidget(self.toolBarWidget)
         self.toolLayout.addWidget(self.run_progress_bar)
-        self.toolLayout.addWidget(self.fill_prediction_progress_bar)
+        # self.toolLayout.addWidget(self.fill_prediction_progress_bar)
 
         if SHOW_SIMPLE_CONTROLS:
             # Remove bottom margin, leaving the rest as "default"
@@ -1547,18 +1547,18 @@ class Ui_Controls(object):  # QtWidgets.QMainWindow
     def action_initialize(self):
         if self.pButton_Start.isEnabled():
             self.cBox_Source.setCurrentIndex(OperationType.calibration.value)
-            self.fill_prediction_progress_bar.setValue(0)
-            self.fill_prediction_progress_bar.setFormat(
-                Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
+            # self.fill_prediction_progress_bar.setValue(0)
+            # self.fill_prediction_progress_bar.setFormat(
+            #     Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
             self.pButton_Start.clicked.emit()
             self.cal_initialized = True
 
     def action_start(self):
         if self.pButton_Start.isEnabled():
             self.cBox_Source.setCurrentIndex(OperationType.measurement.value)
-            self.fill_prediction_progress_bar.setValue(0)
-            self.fill_prediction_progress_bar.setFormat(
-                Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
+            # self.fill_prediction_progress_bar.setValue(0)
+            # self.fill_prediction_progress_bar.setFormat(
+            #     Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
             self.pButton_Start.clicked.emit()
 
     def action_stop(self):
@@ -1580,9 +1580,9 @@ class Ui_Controls(object):  # QtWidgets.QMainWindow
             "<font color=#333333 > Program Status Standby </font>")
         self.cal_initialized = False
         self.tool_Start.setEnabled(False)
-        self.fill_prediction_progress_bar.setValue(0)
-        self.fill_prediction_progress_bar.setFormat(
-            Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
+        # self.fill_prediction_progress_bar.setValue(0)
+        # self.fill_prediction_progress_bar.setFormat(
+        #     Constants.FILL_TYPE_LABEL_MAP.get(0, ""))
         # at least one device connected
         self.tool_TempControl.setEnabled(self.cBox_Port.count() > 1)
 


### PR DESCRIPTION
Commented out the fill_prediction_progress_bar in MainWindow_UI and disabled its backed in MainWindow turning off the Constants.USE_MULTIPROCESS_FILL_FORECASTER flag in Constants.  Goal is to address load issues cropping out the start of our runs and to address user confusion issues with an inaccurate progress bar.