### PR TITLE
Fix #184: Make bigger and bolder, specify a sans-serif font for reada…

### DIFF
--- a/QATCH/processors/Analyze.py
+++ b/QATCH/processors/Analyze.py
@@ -8704,10 +8704,12 @@ class AnalyzerWorker(QtCore.QObject):
                     visc_std = np.std(in_viscosity[idx_start:idx_end+1])
                     shear_min = in_shear_rate[idx_start]
                     shear_max = in_shear_rate[idx_end]
-                    summary_row = "Average viscosity is {:2.2f} cP \u00b1 {:2.2f} for shear rates in range {:2.0f} - {:2.0f} 1/s.".format(
+                    summary_text = "Average viscosity is {:2.2f} cP \u00b1 {:2.2f} for shear rates in range {:2.0f} - {:2.0f} 1/s.".format(
                         visc_avg, visc_std, shear_min, shear_max)
                     # Add summary text to bottom of table data
-                    tableLabel = QtWidgets.QLabel(summary_row)
+                    tableLabel = QtWidgets.QLabel(summary_text)
+                    tableLabel.setStyleSheet("font-family: Roboto, Arial, Calibri, sans-serif; font-size: 12pt; font-weight: bold;")
+                    tableLabel.setWordWrap(True)
                     table_layout.addWidget(tableLabel)
                     # Add centered label to plot data
                     fig4.text(0.53, 0.82,


### PR DESCRIPTION
…bility, and turn on word wrapping so it doesn't force the left splitter widget to be wider than desired with longer label text strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the summary label’s readability with a bold sans‑serif font at 12pt.
  * Enabled word wrapping so longer summaries display cleanly without truncation.
* **Refactor**
  * Performed minor internal cleanup to support the updated label rendering with no impact on functionality or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->