### PR TITLE
Fix #198: Remove 200 PWM Limit on HEAT Mode for TEC Control

### DIFF
--- a/QATCH_Q-1_FW_py_dev/lib/L298NHB/L298NHB.h
+++ b/QATCH_Q-1_FW_py_dev/lib/L298NHB/L298NHB.h
@@ -6,7 +6,7 @@
 
 #include "Arduino.h"
 
-#define MAX_PWR_HEAT 200
+#define MAX_PWR_HEAT 255
 #define MAX_PWR_COOL 255
 
 /**************************************************************************/

--- a/QATCH_Q-1_FW_py_dev/src/main.cpp
+++ b/QATCH_Q-1_FW_py_dev/src/main.cpp
@@ -54,8 +54,8 @@
 
 // Build Info can be queried serially using command: "VERSION"
 #define DEVICE_BUILD "QATCH Q-1"
-#define CODE_VERSION "v2.6b60"
-#define RELEASE_DATE "2025-05-16"
+#define CODE_VERSION "v2.6b62*"
+#define RELEASE_DATE "2025-09-17"
 
 /************************** LIBRARIES **************************/
 


### PR DESCRIPTION
Update MAX_PWR_HEAT to 255 and increment version to denote as a test build version "v2.6b62*" with today's date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased maximum heating power, allowing higher output and finer temperature control; users may see faster warm-up and improved stability.

- Chores
  - Updated displayed software version to v2.6b62*.
  - Updated release date to 2025-09-17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->