### PR TITLE
Bug fix: Add shear_interp_threshold constant for interpolation criteria

### DIFF
--- a/QATCH/core/constants.py
+++ b/QATCH/core/constants.py
@@ -345,6 +345,7 @@ class Constants:
     drop_effect_multiplier_low = 1.025
     drop_effect_multiplier_high = 1.299
     drop_effect_cutoff_freq = 32
+    shear_interp_threshold = 0.15  # n < 0.85 or n > 1.15
 
     ######################
     # BATCH # parameters #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new analysis configuration option: shear interpolation threshold (default 0.15). This provides finer control over interpolation behavior in shear-related analyses while keeping existing workflows unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->