### PR TITLE
Fix #166: Plot Data Out of Sync with Progress Bar During Redraw

### DIFF
--- a/QATCH/VisQAI/src/view/frame_step1.py
+++ b/QATCH/VisQAI/src/view/frame_step1.py
@@ -727,6 +727,7 @@ class FrameStep1(QtWidgets.QDialog):
             Log.d(
                 f"Saving imported formulation #{num_forms+1} to parent for later")
             self.parent.import_formulations.append(form_saved)
+            self.parent.import_run_names.append(self.run_name.text())
         if self.step == 5:
             Log.d("Saving prediction formulation to parent for later")
             self.parent.predict_formulation = form_saved
@@ -1091,6 +1092,7 @@ class FrameStep1(QtWidgets.QDialog):
 
         all_is_good = True
         self.parent.import_formulations.clear()
+        self.parent.import_run_names.clear()
 
         try:
             for i, (_file_name, file_path) in enumerate(self.all_files.items()):
@@ -1108,6 +1110,7 @@ class FrameStep1(QtWidgets.QDialog):
                     return
 
                 self.file_selected(file_path)  # load each run
+                QtCore.QCoreApplication.processEvents()  # redraw plot now
                 if (len(self.run_captured.text()) and
                     len(self.run_updated.text()) and
                     len(self.run_analyzed.text()) and
@@ -1410,6 +1413,7 @@ class FrameStep1(QtWidgets.QDialog):
             if self.step == 3:  # Import Experiments
                 self.list_view.clearSelection()
                 self.parent.import_formulations.clear()
+                self.parent.import_run_names.clear()
             if self.step == 5:  # Predict
                 self.parent.predict_formulation = Formulation()
             # if True:  # Always, all tabs

--- a/QATCH/VisQAI/src/view/frame_step2.py
+++ b/QATCH/VisQAI/src/view/frame_step2.py
@@ -374,8 +374,13 @@ class FrameStep2(QtWidgets.QDialog):
                 Log.e(f"ERROR: Failed to find import formulation index for {run_label}")
                 form_idx = this_idx
 
-            if 0 <= this_idx < len(self.parent.import_formulations) and \
-               self.parent.import_formulations[form_idx].viscosity_profile.is_measured:
+            vf = (0 <= form_idx < len(self.parent.import_formulations))
+            if not vf:
+                Log.e(f"ERROR: form_idx {form_idx} out of range; using {this_idx}")
+                form_idx = min(max(this_idx, 0), len(self.parent.import_formulations) - 1)
+
+            vp_obj = self.parent.import_formulations[form_idx].viscosity_profile if vf else None
+            if vf and vp_obj is not None and getattr(vp_obj, "is_measured", False):
                 # Get the viscosity profile or y target to update with.
                 vp = self._get_viscosity_list(
                     self.parent.import_formulations[form_idx])
@@ -444,16 +449,24 @@ class FrameStep2(QtWidgets.QDialog):
                     run_label = lines[this_idx + 1]
                 else:
                     run_label = f"Import #{this_idx + 1}"
+
                 try:
                     form_idx = self.parent.import_run_names.index(run_label)
                 except ValueError:
                     Log.e(f"ERROR: Failed to find import formulation index for {run_label}")
                     form_idx = this_idx
+
+                vf = (0 <= form_idx < len(self.parent.import_formulations))
+                if not vf:
+                    Log.e(f"ERROR: form_idx {form_idx} out of range; using {this_idx}")
+                    form_idx = min(max(this_idx, 0), len(self.parent.import_formulations) - 1)
+                
                 is_final_run = (this_idx == self.progressState.maximum() - 1)
                 queued_df = self.parent.import_formulations[form_idx].to_dataframe(
                     encoded=False, training=False)
 
-                if self.parent.import_formulations[form_idx].viscosity_profile.is_measured:
+                vp_obj = self.parent.import_formulations[form_idx].viscosity_profile if vf else None
+                if vf and vp_obj is not None and getattr(vp_obj, "is_measured", False):
 
                     # Get the viscosity profile or y target to update with.
                     vp = self._get_viscosity_list(

--- a/QATCH/VisQAI/src/view/main_window.py
+++ b/QATCH/VisQAI/src/view/main_window.py
@@ -354,6 +354,10 @@ class BaseVisQAIWindow(QtWidgets.QMainWindow):
     def hasUnsavedChanges(self):
         """BASE CLASS DEFINITION"""
         return False
+    
+    def isBusy(self):
+        """BASE CLASS DEFINITION"""
+        return False
 
 
 class VisQAIWindow(BaseVisQAIWindow):
@@ -378,6 +382,7 @@ class VisQAIWindow(BaseVisQAIWindow):
 
         self.select_formulation: Formulation = Formulation()
         self.import_formulations: list[Formulation] = []
+        self.import_run_names: list[str] = []
         self.predict_formulation: Formulation = Formulation()
 
     def init_ui(self):
@@ -510,6 +515,10 @@ class VisQAIWindow(BaseVisQAIWindow):
             event.type() == QtCore.QEvent.MouseButtonPress
             and obj == self.tab_widget.tabBar()
         ):
+            # Disallow tab change if learning in-progress
+            if self.isBusy():
+                PopUp.warning(self, "Learning In-Progress...", "Tab change is not allowed while learning.")
+                return True  # ignore click
             now_step = self.tab_widget.currentIndex() + 1
             tab_step = obj.tabAt(event.pos()) + 1
             if tab_step > 0:
@@ -655,6 +664,10 @@ class VisQAIWindow(BaseVisQAIWindow):
     def hasUnsavedChanges(self) -> bool:
         return self._unsaved_changes
 
+    def isBusy(self) -> bool:
+        return hasattr(self.tab_widget.currentWidget(), "timer") and \
+                       self.tab_widget.currentWidget().timer.isActive()
+    
     def reset(self) -> None:
         self.check_user_info()
         self.signedInAs.setText(self.username)

--- a/QATCH/ui/mainWindow_ui.py
+++ b/QATCH/ui/mainWindow_ui.py
@@ -280,6 +280,9 @@ class Ui_Main(object):
             if obj == None:
                 return True
             return
+        if self.parent.VisQAIWin.isBusy():
+            PopUp.warning(self, "Learning In-Progress...", "Mode change is not allowed while learning.")
+            return
         if self.parent.AnalyzeProc.hasUnsavedChanges():
             if PopUp.question(self, Constants.app_title, "You have unsaved changes!\n\nAre you sure you want to close this window?", False):
                 self.parent.AnalyzeProc.clear()  # lose unsaved changes
@@ -340,6 +343,9 @@ class Ui_Main(object):
             Log.d("Analyze mode already active. Skipping mode change request.")
             if obj == None:
                 return True
+            return
+        if self.parent.VisQAIWin.isBusy():
+            PopUp.warning(self, "Learning In-Progress...", "Mode change is not allowed while learning.")
             return
         if self.parent.AnalyzeProc.hasUnsavedChanges():
             if PopUp.question(self, Constants.app_title, "You have unsaved changes!\n\nAre you sure you want to close this window?", False):


### PR DESCRIPTION
Prevent tab/mode change while learning; pull formulation index from file name lookup to keep plots in sync with the run name shown; clear learn UI on tab focus enter to reset progressbar from 100% to 0%; add isBusy() definition for tracking status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prevent changing tabs or modes while learning is in progress, with a clear warning.

- Improvements
  - More reliable mapping of imported runs to formulations during learning and plotting.
  - Automatic UI refresh while processing imported runs for smoother feedback.
  - Auto-cancel stale actions when entering the Learn step to ensure a clean state.

- Bug Fixes
  - Keep imported run names and formulations synchronized to avoid inconsistencies.
  - Reduce UI glitches when no run is selected or when switching imported runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->