### PR TITLE
Fix #220: Excessive Smoothing on Fill Point 3 Selection

### DIFF
--- a/QATCH/processors/Analyze.py
+++ b/QATCH/processors/Analyze.py
@@ -5187,6 +5187,8 @@ class AnalyzeProcess(QtWidgets.QWidget):
             smooth_factor = int(smooth_factor) + (int(smooth_factor + 1) % 2)
             if smooth_factor < 3:
                 smooth_factor = 3
+            if smooth_factor > 69:
+                smooth_factor = 69
             Log.i(TAG, f"Total run time: {total_runtime} secs")
             Log.d(
                 TAG, f"Smoothing: {smooth_factor}"


### PR DESCRIPTION
Restrict upper limit of smoothing factor so it does not get too large on longer runs, causing issues when the run is a shear-thinning formulation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Capped the smoothing factor to a maximum of 69 to prevent extreme values.
  * Improves stability and consistency of analysis outputs under edge cases.
  * No changes to user workflows or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->