### PR TITLE
Reset screensaver timer on pogo button press

### DIFF
--- a/QATCH_Q-1_FW_py_dev/src/main.cpp
+++ b/QATCH_Q-1_FW_py_dev/src/main.cpp
@@ -3585,6 +3585,9 @@ void pogo_button_pressed(bool init)
     return;
   }
 
+  // Kick the screensaver timer
+  time_of_last_msg = micros();
+
   // switch state: open <-> closed 
   pogo_lid_opened = !pogo_lid_opened;
 


### PR DESCRIPTION
Test before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screensaver idle timer to reset when the physical button is pressed, preventing the screensaver from activating during button interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->