### PR TITLE
Fix #269: TFT OP Value Not Updating Due to Invalid Initialization

### DIFF
--- a/QATCH_Q-1_FW_py_dev/src/main.cpp
+++ b/QATCH_Q-1_FW_py_dev/src/main.cpp
@@ -5050,8 +5050,8 @@ void tft_tempcontrol()
     //    Serial.println("Drawing TEC scale...");
     last_temp_label = 255;             // none
     last_line_label[0] = '\0';         // invalidate string
-    last_pv = last_sp = last_op = 255; // impossible values
-    last_pct = 0;
+    last_pv = last_sp = 255;           // impossible values
+    last_op = last_pct = 0;            // not started (yet)
 
     tft.fillScreen(ILI9341_BLACK);
     //    tft.fillRect(0, 22, TFT_WIDTH, 115, fillColor); // only do once, not on every bar update


### PR DESCRIPTION
Fix TFT temperature control initialization values for clarity and display when the TEC starts @ +255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initialization state for temperature control system to properly represent "not started" condition on first run, improving the accuracy of TEC output tracking and power calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->