### PR TITLE
fix #257: Conditionally Remove Band-aid 3 (Hide Initial Fill Region)

### DIFF
--- a/QATCH/processors/Analyze.py
+++ b/QATCH/processors/Analyze.py
@@ -7921,7 +7921,10 @@ class AnalyzerWorker(QtCore.QObject):
 
             ### BANDAID #3 ###
             # PURPOSE: Hide initial fill points when trending in the wrong direction of high-shear
+            # NOTE: This is only enabled for production builds, not dev/nightly builds
             enable_bandaid_3 = True
+            if "_dev" in Constants.app_version or "_nightly" in Constants.app_version:
+                enable_bandaid_3 = False
             hide_initial_fill = False  # if disabled, never force hide initial fill
             remove_initial_fill = False
             point_factor_limit = 0.25


### PR DESCRIPTION
conditionally disable initial fill hiding for dev/nightly builds in AnalyzerWorker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined initial fill display behavior in high-shear trend scenarios for production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->