### PR TITLE
Viscosity Profile Interp bug

### DIFF
--- a/QATCH/VisQAI/src/models/formulation.py
+++ b/QATCH/VisQAI/src/models/formulation.py
@@ -115,7 +115,10 @@ class ViscosityProfile:
         self._vs_monotonic = vs_monotonic
         if len(self.shear_rates) > 1:
             log_srs = np.log10(np.maximum(self.shear_rates, 1e-10))
-            self._interpolator = PchipInterpolator(log_srs, self._vs_monotonic)
+            _, unique_indices = np.unique(log_srs, return_index=True)
+            log_srs = log_srs[unique_indices]
+            vs_unique = self._vs_monotonic[unique_indices]
+            self._interpolator = PchipInterpolator(log_srs, vs_unique)
         else:
             self._interpolator = None
 


### PR DESCRIPTION
PCIHP interpolator requires strictly increasing x-axis shear rates.  When a shear rate is duplicate in analyze_out.csv file, this fails.

Added a simple safe guard to uniquify shear rates to prevent import failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of viscosity profile calculations by correctly handling duplicate values in shear-rate data processing, ensuring stable interpolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->