### PR TITLE
Fix for run not loading Analyze due to error

### DIFF
--- a/QATCH/processors/Analyze.py
+++ b/QATCH/processors/Analyze.py
@@ -5468,10 +5468,10 @@ class AnalyzeProcess(QtWidgets.QWidget):
         ax3.addItem(self.gstars3)
 
         if len(poi_vals) > 0:
-            for i in range(len(poi_vals)):
-                if poi_vals[i] >= len(xs):
+            for i, pt in enumerate(poi_vals):
+                if pt != -1 and not 0 <= pt < len(xs):
                     Log.w(
-                        f"Model point {poi_vals[i]} cannot be used. Skipping point {i+1}.")
+                        f"Model point {pt} cannot be used. Skipping point {i+1}.")
                     poi_vals[i] = -1
             start_stop = poi_vals
 


### PR DESCRIPTION
Add validation for model points in AnalyzeProcess to prevent out-of-bounds errors on run load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for Point of Interest indices to prevent errors when index values exceed available data samples. Invalid indices are now logged as warnings and safely handled instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->