### PR TITLE
Channel 2 Latch not Firing Bug

### DIFF
--- a/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
+++ b/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
@@ -324,6 +324,24 @@ class QModelV6YOLO_Live(QModelV6YOLO_FillClassifier):
                     f"{self._fill_epoch:.1f} s.",
                 )
 
+        # Check whether the *previous* channel's extended-fill latch was armed.
+        # If so, now that this channel has finally been confirmed, emit the message.
+        # This must run before any early return so that channels not in
+        # DURATION_THRESHOLDS (e.g. channel 2) still release the latch for
+        # channel 1 when they are confirmed.
+        prev_channel = channel - 1
+        if self._extended_fill_latched.get(prev_channel, False):
+            _, prev_message = self.DURATION_THRESHOLDS.get(prev_channel, (None, None))
+            if prev_message is not None:
+                Log.i(
+                    self.TAG,
+                    f"Extended fill latch for channel {prev_channel} released on "
+                    f"channel {channel} confirmation - displaying: '{prev_message}'",
+                )
+                self._pending_display_message = prev_message
+                # Consume the latch so it cannot fire again.
+                self._extended_fill_latched[prev_channel] = False
+
         if channel not in self.DURATION_THRESHOLDS:
             return
 
@@ -337,21 +355,6 @@ class QModelV6YOLO_Live(QModelV6YOLO_FillClassifier):
             )
             self._pending_display_message = message
             self._channel_warning_fired[channel] = True
-
-        # Check whether the *previous* channel's extended-fill latch was armed.
-        # If so, now that this channel has finally been confirmed, emit the message.
-        prev_channel = channel - 1
-        if self._extended_fill_latched.get(prev_channel, False):
-            _, prev_message = self.DURATION_THRESHOLDS.get(prev_channel, (None, None))
-            if prev_message is not None:
-                Log.i(
-                    self.TAG,
-                    f"Extended fill latch for channel {prev_channel} released on "
-                    f"channel {channel} confirmation - displaying: '{prev_message}'",
-                )
-                self._pending_display_message = prev_message
-                # Consume the latch so it cannot fire again.
-                self._extended_fill_latched[prev_channel] = False
 
     def _evaluate_duration_threshold(self, channel: int) -> None:
         """Evaluates timed fill-duration thresholds for the currently stable channel.

--- a/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
+++ b/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
@@ -324,7 +324,7 @@ class QModelV6YOLO_Live(QModelV6YOLO_FillClassifier):
                     f"{self._fill_epoch:.1f} s.",
                 )
 
-        # Check whether the *previous* channel's extended-fill latch was armed.
+        # Check whether the previous channel's extended-fill latch was armed.
         # If so, now that this channel has finally been confirmed, emit the message.
         # This must run before any early return so that channels not in
         # DURATION_THRESHOLDS (e.g. channel 2) still release the latch for
@@ -348,7 +348,7 @@ class QModelV6YOLO_Live(QModelV6YOLO_FillClassifier):
         threshold_s, message = self.DURATION_THRESHOLDS[channel]
 
         if threshold_s is None:
-            # Unconditional - emit immediately on confirmation (e.g. 3-channel complete).
+            # emit immediately on confirmation (e.g. 3-channel complete).
             Log.i(
                 self.TAG,
                 f"Channel {channel} fill complete - displaying: '{message}'",


### PR DESCRIPTION
Quick bug fix where channel 1 completes in < 60s from start, channel 2 exceeds 120s and no warning message is displayed.  Issue where there was an early return condition whereby the channel 2 checks could be ignored if channel 1 checks passed with no warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed channel state management in confirmation handling to properly clean up and manage state for all channel configurations, including edge cases, improving system reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->