### PR TITLE
adding fill complete display messages to primary plot

### DIFF
--- a/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
+++ b/QATCH/QModel/src/models/v6_yolo/v6_yolo_live.py
@@ -97,7 +97,7 @@ class QModelV6YOLO_Live(QModelV6YOLO_FillClassifier):
     DURATION_THRESHOLDS: Dict[int, Tuple[Optional[float], str]] = {
         0: (60.0, "Data Ready, You Can Stop"),  # >= 1 min at Initial Fill, no ch1 yet
         1: (120.0, "Data Ready, You Can Stop"),  # >= 2 min at ch1, no ch2 yet
-        3: (None, "Complete, Press Stop"),  # always on 3-channel confirmation
+        3: (None, "Data Ready, Stop"),  # always on 3-channel confirmation
     }
 
     def __init__(self, model_path: str, buffer_window_size: Optional[int] = None):

--- a/QATCH/ui/mainWindow.py
+++ b/QATCH/ui/mainWindow.py
@@ -3469,6 +3469,7 @@ class MainWindow(QtWidgets.QMainWindow):
                             elif pred_int == 3:
                                 status_msg = "Complete, stop"
                                 ui_step = 5
+                                self._fill_display_msg = "Data Ready, Stop"
 
                             if hasattr(self.ControlsWin.ui1, "run_controls"):
                                 self.ControlsWin.ui1.run_controls.update_progress(


### PR DESCRIPTION
Having 3-channel configuration full fill message display on the primary run plot for consistency.  Additionally modified the status message for the fill progress to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated measurement mode status message text for improved clarity and user guidance during data collection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->