### PR TITLE
fix #392: Restrict analysis points to 60% only by removing 80% threshold

### DIFF
--- a/QATCH/processors/Analyze.py
+++ b/QATCH/processors/Analyze.py
@@ -7588,7 +7588,8 @@ class AnalyzerWorker(QtCore.QObject):
                 if debug:
                     ax_dbg.plot(midpoint_p_x, p, color="blue", marker="X")
                 times.append(midpoint_p_i)
-                if p == 0.2 or p == 0.4:
+                # Issue #392: Remove 80% too; only 60% used (if not too off)
+                if p == 0.2 or p == 0.4 or p == 0.8:
                     idx_of_normal_pts_to_remove.append(midpoint_p_i)
                 else:
                     idx_of_normal_pts_to_retain.append(midpoint_p_i)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified analysis data processing to adjust handling of normalized fill points, resolving Issue #392.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->